### PR TITLE
Fix finding project path

### DIFF
--- a/lib/rails-test-runner-view.coffee
+++ b/lib/rails-test-runner-view.coffee
@@ -29,7 +29,11 @@ class RailsTestRunnerView extends ScrollView
     @spinner.show()
     @output.empty()
 
-    projectPath = atom.project.getPaths()[0]
+    # Get the project root and the relative path to the project.
+    [projectPath, relativePath] = atom.project.relativizePath(@filePath)
+    if !projectPath
+      @showError "File #{@filePath} is not part of a project"
+      return
 
     spawn = ChildProcess.spawn
 

--- a/lib/rails-test-runner-view.coffee
+++ b/lib/rails-test-runner-view.coffee
@@ -24,6 +24,7 @@ class RailsTestRunnerView extends ScrollView
     @html $$$ ->
       @h2 'Running rails-test-runner Failed'
       @h3 'An error occurred on running a test'
+      @div result
 
   run: (lineNumber) ->
     @spinner.show()


### PR DESCRIPTION
When multiple projects are opened in Atom, atom-rails-test-runner used the project path of the first project.
This fix uses `@filePath` to find the correct project path

Additionally, showError now shows the error/result as well
